### PR TITLE
[FIX] - Library ESModule build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,8 @@
-import { Config, File, YAMLFrontMatter } from './types';
-import {
-  consoleLogNextmd,
-  flatFiles,
-  generatePathsFromFiles,
-  getContentFromMarkdownFile,
-  getContentPath,
-  getPostsFromNextmd,
-  getSlugFromNextmd,
-  treeContentRepo,
-} from './utils';
+import { Config, File, YAMLFrontMatter } from './types.js';
+import { flatFiles, generatePathsFromFiles, getContentPath } from './utils/fs.js';
+import { treeContentRepo } from './utils/git.js';
+import { consoleLogNextmd } from './utils/logger.js';
+import { getContentFromMarkdownFile, getPostsFromNextmd, getSlugFromNextmd } from './utils/markdown.js';
 
 /**
  * @param config The config for the next-markdown module.
@@ -94,5 +88,6 @@ const NextMarkdown = <PageFrontMatter extends YAMLFrontMatter, PostPageFrontMatt
   };
 };
 
+export * from './types.js';
 export default NextMarkdown;
-export * from './types';
+ 

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import { join } from 'path';
 
-import { File, TreeObject } from '../types';
-import { pathToLocalGitRepo } from './constants';
+import { File, TreeObject } from '../types.js';
+import { pathToLocalGitRepo } from './constants.js';
 
 export const getContentPath = (pathToContent: string, remote: boolean) => {
   return remote ? join(pathToLocalGitRepo, pathToContent) : join(process.cwd(), pathToContent);

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 
-import { Config, YAMLFrontMatter } from '../types';
-import { cmd } from './cmd';
-import { pathToNextmdBranch, pathToNextmdLastUpdate } from './constants';
-import { treeSync } from './fs';
-import { consoleLogNextmd } from './logger';
+import { Config, YAMLFrontMatter } from '../types.js';
+import { cmd } from './cmd.js';
+import { pathToNextmdBranch, pathToNextmdLastUpdate } from './constants.js';
+import { treeSync } from './fs.js';
+import { consoleLogNextmd } from './logger.js';
 
 export const treeContentRepo = async <T extends YAMLFrontMatter>(pathToContent: string, config: Config<T>) => {
   if (config.contentGitRepo) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,0 @@
-export * from './alt';
-export * from './fs';
-export * from './git';
-export * from './markdown';
-export * from './logger';

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -8,9 +8,9 @@ import remarkRehype from 'remark-rehype';
 import { unified } from 'unified';
 import { visit } from 'unist-util-visit';
 
-import { File, YAMLFrontMatter } from '../types';
-import { extractDataFromAlt } from './alt';
-import { getNextmdFromFilePath } from './fs';
+import { File, YAMLFrontMatter } from '../types.js';
+import { extractDataFromAlt } from './alt.js';
+import { getNextmdFromFilePath } from './fs.js';
 
 export const getPostsFromNextmd = async <T extends YAMLFrontMatter>(
   files: File[],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,12 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ES2020",
-    "moduleResolution": "Node",
-    "lib": ["ES2020"],
     "declaration": true,
-    "outDir": "./dist",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "strict": true,
-    "allowSyntheticDefaultImports": true
+    "outDir": "./dist"
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/__tests__/*"],


### PR DESCRIPTION
Typescript supports .js imports for .ts files. see why here : https://github.com/microsoft/TypeScript/issues/16577#issuecomment-754941937

Either that or : 
- use a bundler (IMO overkill for the size of next-markdown)
- use a post-processor typescript plugin to append .js file extensions to relative imports after compilation



